### PR TITLE
[FIX] add dependency to prevent receivable_debt_ids error

### DIFF
--- a/l10n_ar_aeroo_payment_group/__manifest__.py
+++ b/l10n_ar_aeroo_payment_group/__manifest__.py
@@ -30,6 +30,7 @@
         'report_extended_payment_group',
         'l10n_ar_aeroo_base',
         'account_check',
+        'account_debt_management',
         # 'account_voucher_withholding',
     ],
     'external_dependencies': {


### PR DESCRIPTION
Agrego dependencia con payment_debt_management.
This fixes #66 